### PR TITLE
Changed to the latest version of Gallery Project i.e. 3.0.9. Only minor ...

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="3.0.5"
+VERSION="3.0.9"
 URL="http://downloads.sourceforge.net/gallery/gallery-${VERSION}.zip"
 
 dl $URL /usr/local/src

--- a/conf.d/main
+++ b/conf.d/main
@@ -35,6 +35,9 @@ php $WEBROOT/installer/index.php -h localhost -u $DB_USER -p $DB_PASS -d $DB_NAM
 
 /usr/lib/inithooks/bin/gallery.py --email="$ADMIN_MAIL" --pass="$ADMIN_PASS"
 
+# Commenting out the cooliris js as it is not reachable
+sed -i '/e.cooliris.com/s/^/#/' $WEBROOT/modules/slideshow/helpers/slideshow_theme.php
+
 # stop mysql
 /etc/init.d/mysql stop
 


### PR DESCRIPTION
Changed to the latest version of Gallery Project i.e. 3.0.9. Only minor changes so far in upstream releases. Along with it also fixed a bug in the Gallery Project, the change coded to the main script file.
