### PR TITLE
Gallery 3.0.9

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="3.0.5"
+VERSION="3.0.9"
 URL="http://downloads.sourceforge.net/gallery/gallery-${VERSION}.zip"
 
 dl $URL /usr/local/src

--- a/conf.d/main
+++ b/conf.d/main
@@ -35,6 +35,9 @@ php $WEBROOT/installer/index.php -h localhost -u $DB_USER -p $DB_PASS -d $DB_NAM
 
 /usr/lib/inithooks/bin/gallery.py --email="$ADMIN_MAIL" --pass="$ADMIN_PASS"
 
+# Commenting out the cooliris js as it is not reachable
+sed -i '/e.cooliris.com/s/^/#/' $WEBROOT/modules/slideshow/helpers/slideshow_theme.php
+
 # stop mysql
 /etc/init.d/mysql stop
 


### PR DESCRIPTION
I have changed the conf.d/download file for the latest update of Gallery-3.0.9.

Similarly there was a bug, or am not sure if it is a bug. There is a call for a js e.cooliris.com/slideshow/v/37732/go.js from the file /var/www/gallery/modules/slideshow/helpers/slideshow_theme.php  . And this URL is down, so the home page stays in the loading state till the request timeout. Commenting the that js resolved the issue. This issue is there in the upstream and also in sthe earlier versions too, so I guess the URL went down in the near future.

For this change I edited the conf.d/main file.
