### PR TITLE
v18.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,15 @@
+turnkey-gallery-18.0 (1) turnkey; urgency=low
+
+  * Update gallery to 3.1.5.
+
+  * Updated all relevant Debian packages to Bookworm/12 versions; including
+    PHP 8.2.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Thu, 22 Feb 2024 13:35:23 +0100
+
 turnkey-gallery-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,10 +5,8 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="3.1.3"
-#URL="http://downloads.sourceforge.net/gallery/gallery-${VERSION}.zip"
+VERSION="3.1.5"
 URL="https://github.com/bwdutton/gallery3/archive/${VERSION}.zip"
-
 
 dl $URL /usr/local/src
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -25,11 +25,6 @@ service mysql start
 $MYSQL_ADMIN create $DB_NAME
 $MYSQL_BATCH --execute "grant all privileges on $DB_NAME.* to $DB_USER@localhost identified by '$DB_PASS'; flush privileges;"
 
-# configure php.ini to allow short php tag (<? ?> instead of <?php ?>)
-CONF=/etc/php/7.4
-sed -i 's|short_open_tag =.*|short_open_tag = On|' $CONF/cli/php.ini
-sed -i 's|short_open_tag =.*|short_open_tag = On|' $CONF/apache2/php.ini
-
 # unpack and configure gallery
 unzip /usr/local/src/*.zip -d /var/www/
 mv /var/www/gallery3* $WEBROOT


### PR DESCRIPTION
- bump gallery version to 3.1.5
- conf: no longer enable short tags
- update changelog
